### PR TITLE
chat/index: use upstream CoC

### DIFF
--- a/chat/index.html
+++ b/chat/index.html
@@ -15,14 +15,39 @@ layout: page
   </div>
 </div>
 
-<h2 class="pt-4">Code of Conduct</h2>
-<p>We typically only moderate our own channels, but if any of our users are being offensive in other channels don't hesitate to contact us.</p>
-<ol>
-  <li>Be nice, respectful and constructive. Use common sense.</li>
-  <li>No piracy, spam, hate speech, brigading, gore, doxing, racism and any kind of discrimination.</li>
-  <li>No illegal content. Obviously.</li>
-  <li>Please use the english language unless the channel specifies otherwise.</li>
-</ol>
+<h2 id="privacytools.io-code-of-conduct" class="pt-4">Code of Conduct</h2>
+<h3 id="our-pledge">Our Pledge</h3>
+<p>In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of a distinction of any kind, such as age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.</p>
+<h3 id="our-standards">Our Standards</h3>
+<p>Examples of behavior that contributes to creating a positive environment include:</p>
+<ul class="incremental">
+<li>Using welcoming and inclusive language</li>
+<li>Being respectful of differing viewpoints and experiences</li>
+<li>Gracefully accepting constructive criticism</li>
+<li>Focusing on what is best for the community</li>
+<li>Showing empathy towards other community members</li>
+</ul>
+<p>Examples of unacceptable behavior by participants include:</p>
+<ul class="incremental">
+<li>The use of sexualized language or imagery and unwelcome sexual attention or advances</li>
+<li>Trolling, insulting/derogatory, antagonistic comments and personal or political attacks</li>
+<li>Promoting intolerance</li>
+<li>Public or private harassment</li>
+<li>Publishing others’ private information, such as a physical or electronic address, without explicit permission</li>
+<li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
+</ul>
+<h3 id="our-responsibilities">Our Responsibilities</h3>
+<p>Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.</p>
+<p>Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.</p>
+<h3 id="scope">Scope</h3>
+<p>This Code of Conduct applies within all project spaces, and it also applies when an individual is representing as a part of the project or its community in public spaces.</p>
+<p>Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.</p>
+<h3 id="enforcement">Enforcement</h3>
+<p>Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting blacklight447 via email on blacklight447@privacytools.io or <a href="https://forum.privacytools.io/g/team">any team member on our forum</a>. The reports should include information on whether they can be shared to other team members and how much may be told.</p>
+<p>All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.</p>
+<p>Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.</p>
+<h3 id="attribution">Attribution</h3>
+<p>This Code of Conduct is forked from and licensed under Creative Commons BY-4.0, <a href="https://contributor-covenant.org/version/1/4">Contributor Covenant version 1.4</a> by privacytools.io, which you can <a href="https://github.com/privacytoolsIO/privacytools.io/blob/master/CODE_OF_CONDUCT.md">find on our GitHub repository</a>.</p>
 <p>The administration team reserves the right to make <a href="https://xkcd.com/1357/">any</a> moderation-related decisions for any reason.</p>
 
 <h2 class="pt-4" id="homeserverinfo">Connection Information</h2>


### PR DESCRIPTION
I did pandoc -i CODE_OF_CONDUCT.md -o CODE_OF_CONDUCT.html and changed
the hX to one lower, except that I merged the existing and first h2.

Ref: privacytoolsIO/privacytools.io#1305